### PR TITLE
Switch STT public servers

### DIFF
--- a/ovos_stt_plugin_server/__init__.py
+++ b/ovos_stt_plugin_server/__init__.py
@@ -90,7 +90,7 @@ class OVOSHTTPServerSTT(STT):
     @property
     def public_servers(self):
         return [
-            "https://fasterwhisper.tigregotico.pt/stt",
+            "https://whisper.tigregotico.pt/stt",
             "https://stt.smartgic.io/fasterwhisper/stt",
             #"https://whisper.neonaiservices.com/stt"  # TODO -restore once it moves to whisper-turbo
         ]

--- a/ovos_stt_plugin_server/__init__.py
+++ b/ovos_stt_plugin_server/__init__.py
@@ -90,7 +90,7 @@ class OVOSHTTPServerSTT(STT):
     @property
     def public_servers(self):
         return [
-            "https://fasterwhisper.ziggyai.online/stt",
+            "https://fasterwhisper.tigregotico.pt/stt",
             "https://stt.smartgic.io/fasterwhisper/stt",
             #"https://whisper.neonaiservices.com/stt"  # TODO -restore once it moves to whisper-turbo
         ]


### PR DESCRIPTION
For the past few months the https://fasterwhisper.ziggyai.online public server has been unstable which results in a "not so good" first experience for new Open Voice OS users.

Until the server is table again, the https://fasterwhisper.tigregotico.pt public server managed by JarbasAI is added.